### PR TITLE
Header fields and request method support

### DIFF
--- a/TDOAuth.h
+++ b/TDOAuth.h
@@ -79,6 +79,26 @@
                         tokenSecret:(NSString *)tokenSecret;
 
 /**
+  This method allows the caller to specify particular values for many different parameters such
+  as scheme, method, header values and alternate signature hash algorithms.
+
+  @p scheme may be nil, but would generally be either "http" or "https".
+  @p method may be any string value. There is no validation, so remember that all
+  currently-defined HTTP methods are uppercase and the RFC specifies that the method
+  is case-sensitive.
+*/
+
++ (NSURLRequest *)URLRequestForPath:(NSString *)unencodedPathWithoutQuery
+                         parameters:(NSDictionary *)unencodedParameters
+                               host:(NSString *)host
+                        consumerKey:(NSString *)consumerKey
+                     consumerSecret:(NSString *)consumerSecret
+                        accessToken:(NSString *)accessToken
+                        tokenSecret:(NSString *)tokenSecret
+                             scheme:(NSString *)scheme
+                             method:(NSString *)method;
+
+/**
  OAuth requires the UTC timestamp we send to be accurate. The user's device
  may not be, and often isn't. To work around this you should set this to the
  UTC timestamp that you get back in HTTP headers from OAuth servers.

--- a/TDOAuth.h
+++ b/TDOAuth.h
@@ -113,7 +113,7 @@ typedef NS_ENUM(NSInteger, TDOAuthSignatureMethod) {
                         accessToken:(NSString *)accessToken
                         tokenSecret:(NSString *)tokenSecret
                              scheme:(NSString *)scheme
-                             method:(NSString *)method
+                      requestMethod:(NSString *)method
                        headerValues:(NSDictionary *)headerValues
                     signatureMethod:(TDOAuthSignatureMethod)signatureMethod;
 

--- a/TDOAuth.h
+++ b/TDOAuth.h
@@ -29,6 +29,11 @@
 
 #import <Foundation/Foundation.h>
 
+typedef NS_ENUM(NSInteger, TDOAuthSignatureMethod) {
+    TDOAuthSignatureMethodHmacSha1,
+    TDOAuthSignatureMethodHmacSha256,
+};
+
 /**
   This OAuth implementation doesn't cover the whole spec (eg. it’s HMAC only).
   But you'll find it works with almost all the OAuth implementations you need
@@ -94,10 +99,10 @@
  (set to "app-bundle-name/version" your app resources), Accept-Encoding (set to "gzip")
  and the calculated Authentication header. Attempting to specify the latter will be fatal.
  You should also avoid passing in values for the Content-Type and Content-Length header fields.
- @p signatureMethod may be "HMAC-SHA1", "HMAC-SHA256" or nil. Invalid values will be detected
- and the method will return a nil value instead of an NSURLRequest object. nil values for the
- signatureMethod will behave as "HMAC-SHA1". Note that HMAC-256 is not included in the RFC
- for OAuth 1.0a so many servers will not support it.
+ @p signatureMethod accepts an enum and should normally be set to TDOAuthSignatureMethodHmacSha1.
+ You have the option of using HMAC-SHA256 by setting this parameter to 
+ TDOAuthSignatureMethodHmacSha256; this is not included in the RFC for OAuth 1.0a, so most servers
+ will not support it.
 */
 
 + (NSURLRequest *)URLRequestForPath:(NSString *)unencodedPathWithoutQuery
@@ -110,7 +115,7 @@
                              scheme:(NSString *)scheme
                              method:(NSString *)method
                        headerValues:(NSDictionary *)headerValues
-                    signatureMethod:(NSString *)signatureMethod;
+                    signatureMethod:(TDOAuthSignatureMethod)signatureMethod;
 
 /**
  OAuth requires the UTC timestamp we send to be accurate. The user's device

--- a/TDOAuth.h
+++ b/TDOAuth.h
@@ -82,7 +82,7 @@
   This method allows the caller to specify particular values for many different parameters such
   as scheme, method, header values and alternate signature hash algorithms.
 
-  @p scheme may be nil, but would generally be either "http" or "https".
+  @p scheme may be any string value, generally "http" or "https".
   @p method may be any string value. There is no validation, so remember that all
   currently-defined HTTP methods are uppercase and the RFC specifies that the method
   is case-sensitive.

--- a/TDOAuth.h
+++ b/TDOAuth.h
@@ -106,6 +106,12 @@
 +(int)utcTimeOffset;
 +(void)setUtcTimeOffset:(int)offset;
 
+/**
+ DO NOT USE THIS METHOD EXCEPT IN AUTOMATED TESTS. It enables static
+ values for the time and nonce, which would break any production code.
+ */
++(void)enableStaticValuesForAutomatedTests;
+
 @end
 
 

--- a/TDOAuth.h
+++ b/TDOAuth.h
@@ -86,6 +86,14 @@
  @p method may be any string value. There is no validation, so remember that all
  currently-defined HTTP methods are uppercase and the RFC specifies that the method
  is case-sensitive.
+ @p headerValues accepts a hash of key-value pairs (both must be strings) that specify
+ HTTP header values to be included in the resulting URL Request. For example, the argument
+ value @{@"Accept": @"application/json"} will include the header to indicate the server
+ should respond with JSON. Other values are acceptable, depending on the server, but be 
+ careful. Values you supply will override the defaults which are set for User-Agent
+ (set to "app-bundle-name/version" your app resources), Accept-Encoding (set to "gzip")
+ and the calculated Authentication header. Attempting to specify the latter will be fatal.
+ You should also avoid passing in values for the Content-Type and Content-Length header fields.
  @p signatureMethod may be "HMAC-SHA1", "HMAC-SHA256" or nil. Invalid values will be detected
  and the method will return a nil value instead of an NSURLRequest object. nil values for the
  signatureMethod will behave as "HMAC-SHA1". Note that HMAC-256 is not included in the RFC

--- a/TDOAuth.h
+++ b/TDOAuth.h
@@ -33,6 +33,10 @@ typedef NS_ENUM(NSInteger, TDOAuthSignatureMethod) {
     TDOAuthSignatureMethodHmacSha1,
     TDOAuthSignatureMethodHmacSha256,
 };
+typedef NS_ENUM(NSInteger, TDOAuthContentType) {
+    TDOAuthContentTypeUrlEncodedForm,
+    TDOAuthContentTypeJsonObject,
+};
 
 /**
   This OAuth implementation doesn't cover the whole spec (eg. it’s HMAC only).
@@ -88,9 +92,12 @@ typedef NS_ENUM(NSInteger, TDOAuthSignatureMethod) {
  as scheme, method, header values and alternate signature hash algorithms.
 
  @p scheme may be any string value, generally "http" or "https".
- @p method may be any string value. There is no validation, so remember that all
+ @p requestMethod may be any string value. There is no validation, so remember that all
  currently-defined HTTP methods are uppercase and the RFC specifies that the method
  is case-sensitive.
+ @p dataEncoding allows for the transmission of data as either URL-encoded form data or
+ JSON by passing the value TDOAuthContentTypeUrlEncodedForm or TDOAuthContentTypeJsonObject.
+ This parameter is ignored for the requestMethod "GET".
  @p headerValues accepts a hash of key-value pairs (both must be strings) that specify
  HTTP header values to be included in the resulting URL Request. For example, the argument
  value @{@"Accept": @"application/json"} will include the header to indicate the server
@@ -114,10 +121,12 @@ typedef NS_ENUM(NSInteger, TDOAuthSignatureMethod) {
                         tokenSecret:(NSString *)tokenSecret
                              scheme:(NSString *)scheme
                       requestMethod:(NSString *)method
+                       dataEncoding:(TDOAuthContentType)dataEncoding
                        headerValues:(NSDictionary *)headerValues
                     signatureMethod:(TDOAuthSignatureMethod)signatureMethod;
 
 /**
+ 
  OAuth requires the UTC timestamp we send to be accurate. The user's device
  may not be, and often isn't. To work around this you should set this to the
  UTC timestamp that you get back in HTTP headers from OAuth servers.

--- a/TDOAuth.h
+++ b/TDOAuth.h
@@ -79,13 +79,17 @@
                         tokenSecret:(NSString *)tokenSecret;
 
 /**
-  This method allows the caller to specify particular values for many different parameters such
-  as scheme, method, header values and alternate signature hash algorithms.
+ This method allows the caller to specify particular values for many different parameters such
+ as scheme, method, header values and alternate signature hash algorithms.
 
-  @p scheme may be any string value, generally "http" or "https".
-  @p method may be any string value. There is no validation, so remember that all
-  currently-defined HTTP methods are uppercase and the RFC specifies that the method
-  is case-sensitive.
+ @p scheme may be any string value, generally "http" or "https".
+ @p method may be any string value. There is no validation, so remember that all
+ currently-defined HTTP methods are uppercase and the RFC specifies that the method
+ is case-sensitive.
+ @p signatureMethod may be "HMAC-SHA1", "HMAC-SHA256" or nil. Invalid values will be detected
+ and the method will return a nil value instead of an NSURLRequest object. nil values for the
+ signatureMethod will behave as "HMAC-SHA1". Note that HMAC-256 is not included in the RFC
+ for OAuth 1.0a so many servers will not support it.
 */
 
 + (NSURLRequest *)URLRequestForPath:(NSString *)unencodedPathWithoutQuery
@@ -96,7 +100,9 @@
                         accessToken:(NSString *)accessToken
                         tokenSecret:(NSString *)tokenSecret
                              scheme:(NSString *)scheme
-                             method:(NSString *)method;
+                             method:(NSString *)method
+                       headerValues:(NSDictionary *)headerValues
+                    signatureMethod:(NSString *)signatureMethod;
 
 /**
  OAuth requires the UTC timestamp we send to be accurate. The user's device

--- a/TDOAuth.h
+++ b/TDOAuth.h
@@ -101,13 +101,13 @@ typedef NS_ENUM(NSInteger, TDOAuthContentType) {
  @p headerValues accepts a hash of key-value pairs (both must be strings) that specify
  HTTP header values to be included in the resulting URL Request. For example, the argument
  value @{@"Accept": @"application/json"} will include the header to indicate the server
- should respond with JSON. Other values are acceptable, depending on the server, but be 
+ should respond with JSON. Other values are acceptable, depending on the server, but be
  careful. Values you supply will override the defaults which are set for User-Agent
  (set to "app-bundle-name/version" your app resources), Accept-Encoding (set to "gzip")
  and the calculated Authentication header. Attempting to specify the latter will be fatal.
  You should also avoid passing in values for the Content-Type and Content-Length header fields.
  @p signatureMethod accepts an enum and should normally be set to TDOAuthSignatureMethodHmacSha1.
- You have the option of using HMAC-SHA256 by setting this parameter to 
+ You have the option of using HMAC-SHA256 by setting this parameter to
  TDOAuthSignatureMethodHmacSha256; this is not included in the RFC for OAuth 1.0a, so most servers
  will not support it.
 */
@@ -126,7 +126,7 @@ typedef NS_ENUM(NSInteger, TDOAuthContentType) {
                     signatureMethod:(TDOAuthSignatureMethod)signatureMethod;
 
 /**
- 
+
  OAuth requires the UTC timestamp we send to be accurate. The user's device
  may not be, and often isn't. To work around this you should set this to the
  UTC timestamp that you get back in HTTP headers from OAuth servers.

--- a/TDOAuth.h
+++ b/TDOAuth.h
@@ -134,12 +134,6 @@ typedef NS_ENUM(NSInteger, TDOAuthContentType) {
 +(int)utcTimeOffset;
 +(void)setUtcTimeOffset:(int)offset;
 
-/**
- DO NOT USE THIS METHOD EXCEPT IN AUTOMATED TESTS. It enables static
- values for the time and nonce, which would break any production code.
- */
-+(void)enableStaticValuesForAutomatedTests;
-
 @end
 
 

--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -47,26 +47,26 @@
 #endif
 
 static int TDOAuthUTCTimeOffset = 0;
-static BOOL TDOAuthUseStaticValuesForAutomatedTesting = NO;
+/* TDOAUTH_USE_STATIC_VALUES_FOR_AUTOMATIC_TESTING is defined in the XCode project. */
 
 static NSString* nonce() {
-    if (TDOAuthUseStaticValuesForAutomatedTesting) {
-        return @"static-nonce-for-testing";
-    } else {
-        CFUUIDRef uuid = CFUUIDCreate(NULL);
-        CFStringRef s = CFUUIDCreateString(NULL, uuid);
-        CFRelease(uuid);
-        return (__bridge_transfer NSString *)s;
-    }
+#ifdef TDOAUTH_USE_STATIC_VALUES_FOR_AUTOMATIC_TESTING
+    return @"static-nonce-for-testing";
+#else
+    CFUUIDRef uuid = CFUUIDCreate(NULL);
+    CFStringRef s = CFUUIDCreateString(NULL, uuid);
+    CFRelease(uuid);
+    return (__bridge_transfer NSString *)s;
+#endif
 }
 
 static NSString* timestamp() {
     time_t t;
-    if (TDOAuthUseStaticValuesForAutomatedTesting) {
-        t = 1456789012;
-    } else {
-        time(&t);
-    }
+#ifdef TDOAUTH_USE_STATIC_VALUES_FOR_AUTOMATIC_TESTING
+    t = 1456789012;
+#else
+    time(&t);
+#endif
     mktime(gmtime(&t));
     return [NSString stringWithFormat:@"%ld", t + TDOAuthUTCTimeOffset];
 }
@@ -379,8 +379,4 @@ static NSString* timestamp() {
     TDOAuthUTCTimeOffset = offset;
 }
 
-+(void)enableStaticValuesForAutomatedTests
-{
-    TDOAuthUseStaticValuesForAutomatedTesting = YES;
-}
 @end

--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -227,7 +227,7 @@ static NSString* timestamp() {
                           accessToken:accessToken
                           tokenSecret:tokenSecret
                                scheme:@"http"
-                               method:@"GET"
+                        requestMethod:@"GET"
                          headerValues:nil
                       signatureMethod:TDOAuthSignatureMethodHmacSha1];
 }
@@ -240,7 +240,7 @@ static NSString* timestamp() {
                         accessToken:(NSString *)accessToken
                         tokenSecret:(NSString *)tokenSecret
                              scheme:(NSString *)scheme
-                             method:(NSString *)method
+                      requestMethod:(NSString *)method
                        headerValues:(NSDictionary *)headerValues
                     signatureMethod:(TDOAuthSignatureMethod)signatureMethod;
 {
@@ -312,7 +312,7 @@ static NSString* timestamp() {
                           accessToken:accessToken
                           tokenSecret:tokenSecret
                                scheme:scheme
-                               method:@"GET"
+                        requestMethod:@"GET"
                          headerValues:nil
                       signatureMethod:TDOAuthSignatureMethodHmacSha1];
 }
@@ -333,7 +333,7 @@ static NSString* timestamp() {
                           accessToken:accessToken
                           tokenSecret:tokenSecret
                                scheme:@"https"
-                               method:@"POST"
+                        requestMethod:@"POST"
                          headerValues:nil
                       signatureMethod:TDOAuthSignatureMethodHmacSha1];
     

--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -93,7 +93,7 @@ static NSString* timestamp() {
     NSString *smString;
     if (signatureMethod == TDOAuthSignatureMethodHmacSha256) {
         smString = @"HMAC-SHA256";
-    } else if ((signatureMethod == TDOAuthSignatureMethodHmacSha1) || (!signatureMethod)) {
+    } else if (signatureMethod == TDOAuthSignatureMethodHmacSha1) {
         smString = @"HMAC-SHA1";
     } else {
         self = nil;

--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -162,13 +162,23 @@ static NSString* timestamp() {
     return header;
 }
 
-- (NSMutableURLRequest *)request {
+- (NSMutableURLRequest *)requestWithHeaderValues:(NSDictionary *)headerValues {
     NSMutableURLRequest *rq = [NSMutableURLRequest requestWithURL:url
                                                       cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
                                                   timeoutInterval:TDOAuthURLRequestTimeout];
     [rq setValue:OMGUserAgent() forHTTPHeaderField:@"User-Agent"];
     [rq setValue:[self authorizationHeader] forHTTPHeaderField:@"Authorization"];
     [rq setValue:@"gzip" forHTTPHeaderField:@"Accept-Encoding"];
+    if (headerValues) // nil is allowed
+    {
+        for (NSString* key in headerValues) {
+            id value = [headerValues objectForKey:key];
+            if ([value isKindOfClass:[NSString class]])
+            {
+                [rq setValue:value forHTTPHeaderField:key];
+            }
+        }
+    }
     [rq setHTTPMethod:method];
     return rq;
 }
@@ -261,14 +271,14 @@ static NSString* timestamp() {
     {
         oauth->url = [[NSURL alloc] initWithString:[NSString stringWithFormat:@"%@://%@%@",
                                                     scheme, host, path]];
-        rq = [oauth request];
+        rq = [oauth requestWithHeaderValues:headerValues];
     }
     else
     {
         oauth->url = [[NSURL alloc] initWithString:[NSString stringWithFormat:@"%@://%@%@",
                                                     scheme, host, unencodedPathWithoutQuery]];
         NSMutableString *postbody = [oauth setParameters:unencodedParameters];
-        rq = [oauth request];
+        rq = [oauth requestWithHeaderValues:headerValues];
 
         if (postbody.length) {
             [rq setHTTPBody:[postbody dataUsingEncoding:NSUTF8StringEncoding]];

--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -47,17 +47,26 @@
 #endif
 
 static int TDOAuthUTCTimeOffset = 0;
+static BOOL TDOAuthUseStaticValuesForAutomatedTesting = NO;
 
 static NSString* nonce() {
-    CFUUIDRef uuid = CFUUIDCreate(NULL);
-    CFStringRef s = CFUUIDCreateString(NULL, uuid);
-    CFRelease(uuid);
-    return (__bridge_transfer NSString *)s;
+    if (TDOAuthUseStaticValuesForAutomatedTesting) {
+        return @"static-nonce-for-testing";
+    } else {
+        CFUUIDRef uuid = CFUUIDCreate(NULL);
+        CFStringRef s = CFUUIDCreateString(NULL, uuid);
+        CFRelease(uuid);
+        return (__bridge_transfer NSString *)s;
+    }
 }
 
 static NSString* timestamp() {
     time_t t;
-    time(&t);
+    if (TDOAuthUseStaticValuesForAutomatedTesting) {
+        t = 1456789012;
+    } else {
+        time(&t);
+    }
     mktime(gmtime(&t));
     return [NSString stringWithFormat:@"%ld", t + TDOAuthUTCTimeOffset];
 }
@@ -299,4 +308,8 @@ static NSString* timestamp() {
     TDOAuthUTCTimeOffset = offset;
 }
 
++(void)enableStaticValuesForAutomatedTests
+{
+    TDOAuthUseStaticValuesForAutomatedTesting = YES;
+}
 @end

--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -100,7 +100,7 @@ static NSString* timestamp() {
         return self;
     }
     signature_method = signatureMethod;
-    
+
     oauthParams = [NSDictionary dictionaryWithObjectsAndKeys:
                   consumerKey,  @"oauth_consumer_key",
                   nonce(),      @"oauth_nonce",
@@ -140,7 +140,7 @@ static NSString* timestamp() {
 - (NSString *)signature {
     NSData *sigbase = [[self signature_base] dataUsingEncoding:NSUTF8StringEncoding];
     NSData *secret = [signature_secret dataUsingEncoding:NSUTF8StringEncoding];
-    
+
     NSMutableData *digest;
     NSString *result;
     if (signature_method == TDOAuthSignatureMethodHmacSha256) {
@@ -268,7 +268,7 @@ static NSString* timestamp() {
         // not the most all encompassing solution, but in practice it seems to work
         // everywhere and means that programmer error is *much* less likely.
         NSString *encodedPathWithoutQuery = [unencodedPathWithoutQuery stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-        
+
         id path = [oauth setParameters:unencodedParameters];
         if (path) {
             [path insertString:@"?" atIndex:0];
@@ -366,7 +366,7 @@ static NSString* timestamp() {
                          dataEncoding:TDOAuthContentTypeUrlEncodedForm
                          headerValues:nil
                       signatureMethod:TDOAuthSignatureMethodHmacSha1];
-    
+
 }
 
 +(int)utcTimeOffset

--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -210,7 +210,7 @@ static NSString* timestamp() {
                              scheme:(NSString *)scheme
                              method:(NSString *)method;
 {
-    if (!host || !unencodedPathWithoutQuery || !method)
+    if (!host || !unencodedPathWithoutQuery || !scheme || !method)
         return nil;
 
     TDOAuth *oauth = [[TDOAuth alloc] initWithConsumerKey:consumerKey

--- a/TDOAuthTest/OMGHTTPURLRQ/OMGUserAgent.h
+++ b/TDOAuthTest/OMGHTTPURLRQ/OMGUserAgent.h
@@ -1,0 +1,3 @@
+@class NSString;
+
+NSString *OMGUserAgent();

--- a/TDOAuthTest/OMGHTTPURLRQ/OMGUserAgent.m
+++ b/TDOAuthTest/OMGHTTPURLRQ/OMGUserAgent.m
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+#import "OMGUserAgent.h"
+
+NSString *OMGUserAgent() {
+    static NSString *ua;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        id info = [NSBundle mainBundle].infoDictionary;
+        id name = info[@"CFBundleDisplayName"] ?: info[(__bridge NSString *)kCFBundleIdentifierKey];
+        id vers = (__bridge id)CFBundleGetValueForInfoDictionaryKey(CFBundleGetMainBundle(), kCFBundleVersionKey) ?: info[(__bridge NSString *)kCFBundleVersionKey];
+      #ifdef UIKIT_EXTERN
+        float scale = ([[UIScreen mainScreen] respondsToSelector:@selector(scale)] ? [UIScreen mainScreen].scale : 1.0f);
+        ua = [NSString stringWithFormat:@"%@/%@ (%@; iOS %@; Scale/%0.2f)", name, vers, [UIDevice currentDevice].model, [UIDevice currentDevice].systemVersion, scale];
+      #else
+        ua = [NSString stringWithFormat:@"%@/%@", name, vers];
+      #endif
+    });
+    return ua;
+}

--- a/TDOAuthTest/OMGHTTPURLRQ/README.markdown
+++ b/TDOAuthTest/OMGHTTPURLRQ/README.markdown
@@ -1,0 +1,145 @@
+# OMGHTTPURLRQ
+
+Vital extensions to `NSURLRequest` that Apple left out for some reason.
+
+```objc
+NSMutableURLRequest *rq = [OMGHTTPURLRQ GET:@"http://api.com":@{@"key": @"value"}];
+
+// application/x-www-form-urlencoded
+NSMutableURLRequest *rq = [OMGHTTPURLRQ POST:@"http://api.com":@{@"key": @"value"}];
+
+// application/json
+NSMutableURLRequest *rq = [OMGHTTPURLRQ POST:@"http://api.com" JSON:@{@"key": @"value"}];
+
+// PUT
+NSMutableURLRequest *rq = [OMGHTTPURLRQ PUT:@"http://api.com":@{@"key": @"value"}];
+
+// DELETE
+NSMutableURLRequest *rq = [OMGHTTPURLRQ DELETE:@"http://api.com":@{@"key": @"value"}];
+```
+
+You can then pass these to an `NSURLConnection` or `NSURLSession`.
+
+
+## `multipart/form-data`
+
+OMG! Constructing multipart/form-data for POST requests is complicated, let us do it for you:
+
+```objc
+
+OMGMultipartFormData *multipartFormData = [OMGMultipartFormData new];
+
+NSData *data1 = [NSData dataWithContentsOfFile:@"myimage1.png"];
+[multipartFormData addFile:data1 parameterName:@"file1" filename:@"myimage1.png" contentType:@"image/png"];
+
+// Ideally you would not want to re-encode the PNG, but often it is
+// tricky to avoid it.
+UIImage *image2 = [UIImage imageNamed:@"image2"];
+NSData *data2 = UIImagePNGRepresentation(image2);
+[multipartFormData addFile:data2 parameterName:@"file2" filename:@"myimage2.png" contentType:@"image/png"];
+
+// SUPER Ideally you would not want to re-encode the JPEG as the process
+// is lossy. If you image comes from the AssetLibrary you *CAN* get the
+// original `NSData`. See stackoverflow.com.
+UIImage *image3 = [UIImage imageNamed:@"image3"];
+NSData *data3 = UIImageJPEGRepresentation(image3);
+[multipartFormData addFile:data3 parameterName:@"file2" filename:@"myimage3.jpeg" contentType:@"image/jpeg"];
+
+NSMutableURLRequest *rq = [OMGHTTPURLRQ POST:url:multipartFormData];
+```
+
+Now feed `rq` to `[NSURLConnection sendSynchronousRequest:returningResponse:error:`.
+
+
+## Configuring an `NSURLSessionUploadTask`
+
+If you need to use `NSURLSession`’s `uploadTask:` but you have become frustrated  because your endpoint expects a multipart/form-data POST request and `NSURLSession` sends the data *raw*, use this:
+
+```objc
+id config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:someID];
+id session = [NSURLSession sessionWithConfiguration:config delegate:someObject delegateQueue:[NSOperationQueue new]];
+
+OMGMultipartFormData *multipartFormData = [OMGMultipartFormData new];
+[multipartFormDatabuilder addFile:data parameterName:@"file" filename:nil contentType:nil];
+
+NSURLRequest *rq = [OMGHTTPURLRQ POST:urlString:multipartFormData];
+
+id path = [[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject] stringByAppendingPathComponent:@"upload.NSData"];
+[rq.HTTPBody writeToFile:path atomically:YES];
+
+[[session uploadTaskWithRequest:rq fromFile:[NSURL fileURLWithPath:path]] resume];
+```
+
+
+## OMGUserAgent
+
+If you just need a sensible UserAgent string for your application you can `pod OMGHTTPURLRQ/UserAgent` and then:
+
+```objc
+#import <OMGHTTPURLRQ/OMGUserAgent.h>
+
+NSString *userAgent = OMGUserAgent();
+```
+
+OMGHTTPURLRQ adds this User-Agent to all requests it generates automatically.
+
+So for URLRequests generated **other** than by OMGHTTPURLRQ you would do:
+
+```objc
+[someURLRequest addValue:OMGUserAgent() forHTTPHeaderField:@"User-Agent"];
+```
+
+
+# Twitter Reverse Auth
+
+You need an OAuth library, here we use the [TDOAuth](https://github.com/tweetdeck/TDOAuth) pod. You also need
+your API keys that registering at https://dev.twitter.com will provide
+you.
+
+```objc
+NSMutableURLRequest *rq = [TDOAuth URLRequestForPath:@"/oauth/request_token" POSTParameters:@{@"x_auth_mode" : @"reverse_auth"} host:@"api.twitter.com"consumerKey:APIKey consumerSecret:APISecret accessToken:nil tokenSecret:nil];
+[rq addValue:OMGUserAgent() forHTTPHeaderField:@"User-Agent"];
+
+[NSURLConnection sendAsynchronousRequest:rq queue:nil completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
+    id oauth = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    SLRequest *reverseAuth = [SLRequest requestForServiceType:SLServiceTypeTwitter requestMethod:SLRequestMethodPOST URL:[NSURL URLWithString:@"https://api.twitter.com/oauth/access_token"] parameters:@{
+        @"x_reverse_auth_target": APIKey,
+        @"x_reverse_auth_parameters": oauth
+    }];
+    reverseAuth.account = account;
+    [reverseAuth performRequestWithHandler:^(NSData *data, NSHTTPURLResponse *urlResponse, NSError *error) {
+        id creds = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        id credsDict = [NSMutableDictionary new];
+        for (__strong id pair in [creds componentsSeparatedByString:@"&"]) {
+            pair = [pair componentsSeparatedByString:@"="];
+            credsDict[pair[0]] = pair[1];
+        }
+        NSLog(@"%@", credsDict);
+    }];
+}];
+```
+
+
+# License
+
+```
+Copyright 2014 Max Howell <mxcl@me.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```

--- a/TDOAuthTest/TDOAuthTest.xcodeproj/project.pbxproj
+++ b/TDOAuthTest/TDOAuthTest.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 		C445D4A11ABF7B850076B639 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = TDOAUTH_USE_STATIC_VALUES_FOR_AUTOMATIC_TESTING;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -199,6 +200,7 @@
 		C445D4A21ABF7B850076B639 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = TDOAUTH_USE_STATIC_VALUES_FOR_AUTOMATIC_TESTING;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,

--- a/TDOAuthTest/TDOAuthTest.xcodeproj/project.pbxproj
+++ b/TDOAuthTest/TDOAuthTest.xcodeproj/project.pbxproj
@@ -186,6 +186,11 @@
 		C445D4A11ABF7B850076B639 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					./OMGHTTPURLRQ/,
+				);
 				INFOPLIST_FILE = "";
 				"INFOPLIST_FILE[sdk=*]" = "";
 			};
@@ -194,6 +199,11 @@
 		C445D4A21ABF7B850076B639 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					./OMGHTTPURLRQ/,
+				);
 				INFOPLIST_FILE = "";
 			};
 			name = Release;

--- a/TDOAuthTest/TDOAuthTest.xcodeproj/project.pbxproj
+++ b/TDOAuthTest/TDOAuthTest.xcodeproj/project.pbxproj
@@ -1,0 +1,313 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		C43B88641AC064C9005FAD49 /* TDOAuth.m in Sources */ = {isa = PBXBuildFile; fileRef = C43B88631AC064C9005FAD49 /* TDOAuth.m */; };
+		C445D4AB1ABF7B9C0076B639 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C445D4AA1ABF7B9C0076B639 /* XCTest.framework */; };
+		C445D4B11ABF7B9C0076B639 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = C445D4AF1ABF7B9C0076B639 /* InfoPlist.strings */; };
+		C445D4B31ABF7B9C0076B639 /* TDOAuthTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C445D4B21ABF7B9C0076B639 /* TDOAuthTest.m */; };
+		C4B6B4711ABF82170037A64C /* OMGUserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = C4B6B46F1ABF82170037A64C /* OMGUserAgent.m */; };
+		C4B6B4721ABF82170037A64C /* README.markdown in Resources */ = {isa = PBXBuildFile; fileRef = C4B6B4701ABF82170037A64C /* README.markdown */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		C43B88621AC064C9005FAD49 /* TDOAuth.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TDOAuth.h; path = ../TDOAuth.h; sourceTree = "<group>"; };
+		C43B88631AC064C9005FAD49 /* TDOAuth.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TDOAuth.m; path = ../TDOAuth.m; sourceTree = "<group>"; };
+		C445D4A71ABF7B9C0076B639 /* TDOAuthTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TDOAuthTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C445D4AA1ABF7B9C0076B639 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		C445D4AE1ABF7B9C0076B639 /* TDOAuthTest-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "TDOAuthTest-Info.plist"; sourceTree = "<group>"; };
+		C445D4B01ABF7B9C0076B639 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		C445D4B21ABF7B9C0076B639 /* TDOAuthTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TDOAuthTest.m; sourceTree = "<group>"; };
+		C445D4B41ABF7B9C0076B639 /* TDOAuthTest-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TDOAuthTest-Prefix.pch"; sourceTree = "<group>"; };
+		C45943051ABF849800C7A744 /* TDOAuthTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TDOAuthTest.h; sourceTree = "<group>"; };
+		C4B6B46E1ABF82170037A64C /* OMGUserAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OMGUserAgent.h; sourceTree = "<group>"; };
+		C4B6B46F1ABF82170037A64C /* OMGUserAgent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OMGUserAgent.m; sourceTree = "<group>"; };
+		C4B6B4701ABF82170037A64C /* README.markdown */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.markdown; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		C445D4A41ABF7B9C0076B639 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C445D4AB1ABF7B9C0076B639 /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		C445D49C1ABF7B850076B639 = {
+			isa = PBXGroup;
+			children = (
+				C43B88621AC064C9005FAD49 /* TDOAuth.h */,
+				C43B88631AC064C9005FAD49 /* TDOAuth.m */,
+				C445D4AC1ABF7B9C0076B639 /* TDOAuthTest */,
+				C4B6B46D1ABF82170037A64C /* OMGHTTPURLRQ */,
+				C445D4A91ABF7B9C0076B639 /* Frameworks */,
+				C445D4A81ABF7B9C0076B639 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		C445D4A81ABF7B9C0076B639 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C445D4A71ABF7B9C0076B639 /* TDOAuthTest.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		C445D4A91ABF7B9C0076B639 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				C445D4AA1ABF7B9C0076B639 /* XCTest.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C445D4AC1ABF7B9C0076B639 /* TDOAuthTest */ = {
+			isa = PBXGroup;
+			children = (
+				C445D4B21ABF7B9C0076B639 /* TDOAuthTest.m */,
+				C45943051ABF849800C7A744 /* TDOAuthTest.h */,
+				C445D4AD1ABF7B9C0076B639 /* Supporting Files */,
+			);
+			path = TDOAuthTest;
+			sourceTree = "<group>";
+		};
+		C445D4AD1ABF7B9C0076B639 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				C445D4AE1ABF7B9C0076B639 /* TDOAuthTest-Info.plist */,
+				C445D4AF1ABF7B9C0076B639 /* InfoPlist.strings */,
+				C445D4B41ABF7B9C0076B639 /* TDOAuthTest-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		C4B6B46D1ABF82170037A64C /* OMGHTTPURLRQ */ = {
+			isa = PBXGroup;
+			children = (
+				C4B6B46E1ABF82170037A64C /* OMGUserAgent.h */,
+				C4B6B46F1ABF82170037A64C /* OMGUserAgent.m */,
+				C4B6B4701ABF82170037A64C /* README.markdown */,
+			);
+			name = OMGHTTPURLRQ;
+			path = TDOAuthTest/OMGHTTPURLRQ;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		C445D4A61ABF7B9C0076B639 /* TDOAuthTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C445D4B51ABF7B9C0076B639 /* Build configuration list for PBXNativeTarget "TDOAuthTest" */;
+			buildPhases = (
+				C445D4A31ABF7B9C0076B639 /* Sources */,
+				C445D4A41ABF7B9C0076B639 /* Frameworks */,
+				C445D4A51ABF7B9C0076B639 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TDOAuthTest;
+			productName = TDOAuthTest;
+			productReference = C445D4A71ABF7B9C0076B639 /* TDOAuthTest.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		C445D49D1ABF7B850076B639 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0510;
+			};
+			buildConfigurationList = C445D4A01ABF7B850076B639 /* Build configuration list for PBXProject "TDOAuthTest" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = C445D49C1ABF7B850076B639;
+			productRefGroup = C445D4A81ABF7B9C0076B639 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C445D4A61ABF7B9C0076B639 /* TDOAuthTest */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		C445D4A51ABF7B9C0076B639 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C4B6B4721ABF82170037A64C /* README.markdown in Resources */,
+				C445D4B11ABF7B9C0076B639 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		C445D4A31ABF7B9C0076B639 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C445D4B31ABF7B9C0076B639 /* TDOAuthTest.m in Sources */,
+				C43B88641AC064C9005FAD49 /* TDOAuth.m in Sources */,
+				C4B6B4711ABF82170037A64C /* OMGUserAgent.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		C445D4AF1ABF7B9C0076B639 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				C445D4B01ABF7B9C0076B639 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		C445D4A11ABF7B850076B639 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "";
+				"INFOPLIST_FILE[sdk=*]" = "";
+			};
+			name = Debug;
+		};
+		C445D4A21ABF7B850076B639 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "";
+			};
+			name = Release;
+		};
+		C445D4B61ABF7B9C0076B639 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "TDOAuthTest/TDOAuthTest-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "TDOAuthTest/TDOAuthTest-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		C445D4B71ABF7B9C0076B639 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "TDOAuthTest/TDOAuthTest-Prefix.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "TDOAuthTest/TDOAuthTest-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C445D4A01ABF7B850076B639 /* Build configuration list for PBXProject "TDOAuthTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C445D4A11ABF7B850076B639 /* Debug */,
+				C445D4A21ABF7B850076B639 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C445D4B51ABF7B9C0076B639 /* Build configuration list for PBXNativeTarget "TDOAuthTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C445D4B61ABF7B9C0076B639 /* Debug */,
+				C445D4B71ABF7B9C0076B639 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = C445D49D1ABF7B850076B639 /* Project object */;
+}

--- a/TDOAuthTest/TDOAuthTest.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/TDOAuthTest/TDOAuthTest.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:TDOAuthTest.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/TDOAuthTest/TDOAuthTest.xcworkspace/contents.xcworkspacedata
+++ b/TDOAuthTest/TDOAuthTest.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:TDOAuthTest.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/TDOAuthTest/TDOAuthTest.xcworkspace/xcshareddata/TDOAuthTest.xccheckout
+++ b/TDOAuthTest/TDOAuthTest.xcworkspace/xcshareddata/TDOAuthTest.xccheckout
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
+	<key>IDESourceControlProjectIdentifier</key>
+	<string>34274486-C984-4B3E-BA14-97AE24DFC665</string>
+	<key>IDESourceControlProjectName</key>
+	<string>TDOAuthTest</string>
+	<key>IDESourceControlProjectOriginsDictionary</key>
+	<dict>
+		<key>1704EE97-38C3-434F-804B-96F1779984EB</key>
+		<string>https://github.com/tweetdeck/TDOAuth.git</string>
+	</dict>
+	<key>IDESourceControlProjectPath</key>
+	<string>TDOAuthTest/TDOAuthTest.xcworkspace</string>
+	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
+	<dict>
+		<key>1704EE97-38C3-434F-804B-96F1779984EB</key>
+		<string>../..</string>
+	</dict>
+	<key>IDESourceControlProjectURL</key>
+	<string>https://github.com/tweetdeck/TDOAuth.git</string>
+	<key>IDESourceControlProjectVersion</key>
+	<integer>110</integer>
+	<key>IDESourceControlProjectWCCIdentifier</key>
+	<string>1704EE97-38C3-434F-804B-96F1779984EB</string>
+	<key>IDESourceControlProjectWCConfigurations</key>
+	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>1704EE97-38C3-434F-804B-96F1779984EB</string>
+			<key>IDESourceControlWCCName</key>
+			<string>TDOAuth</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/TDOAuthTest/TDOAuthTest/OMGHTTPURLRQ/OMGUserAgent.h
+++ b/TDOAuthTest/TDOAuthTest/OMGHTTPURLRQ/OMGUserAgent.h
@@ -1,0 +1,3 @@
+@class NSString;
+
+NSString *OMGUserAgent();

--- a/TDOAuthTest/TDOAuthTest/OMGHTTPURLRQ/OMGUserAgent.m
+++ b/TDOAuthTest/TDOAuthTest/OMGHTTPURLRQ/OMGUserAgent.m
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+#import "OMGUserAgent.h"
+
+NSString *OMGUserAgent() {
+    static NSString *ua;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        id info = [NSBundle mainBundle].infoDictionary;
+        id name = info[@"CFBundleDisplayName"] ?: info[(__bridge NSString *)kCFBundleIdentifierKey];
+        id vers = (__bridge id)CFBundleGetValueForInfoDictionaryKey(CFBundleGetMainBundle(), kCFBundleVersionKey) ?: info[(__bridge NSString *)kCFBundleVersionKey];
+      #ifdef UIKIT_EXTERN
+        float scale = ([[UIScreen mainScreen] respondsToSelector:@selector(scale)] ? [UIScreen mainScreen].scale : 1.0f);
+        ua = [NSString stringWithFormat:@"%@/%@ (%@; iOS %@; Scale/%0.2f)", name, vers, [UIDevice currentDevice].model, [UIDevice currentDevice].systemVersion, scale];
+      #else
+        ua = [NSString stringWithFormat:@"%@/%@", name, vers];
+      #endif
+    });
+    return ua;
+}

--- a/TDOAuthTest/TDOAuthTest/OMGHTTPURLRQ/README.markdown
+++ b/TDOAuthTest/TDOAuthTest/OMGHTTPURLRQ/README.markdown
@@ -1,0 +1,145 @@
+# OMGHTTPURLRQ
+
+Vital extensions to `NSURLRequest` that Apple left out for some reason.
+
+```objc
+NSMutableURLRequest *rq = [OMGHTTPURLRQ GET:@"http://api.com":@{@"key": @"value"}];
+
+// application/x-www-form-urlencoded
+NSMutableURLRequest *rq = [OMGHTTPURLRQ POST:@"http://api.com":@{@"key": @"value"}];
+
+// application/json
+NSMutableURLRequest *rq = [OMGHTTPURLRQ POST:@"http://api.com" JSON:@{@"key": @"value"}];
+
+// PUT
+NSMutableURLRequest *rq = [OMGHTTPURLRQ PUT:@"http://api.com":@{@"key": @"value"}];
+
+// DELETE
+NSMutableURLRequest *rq = [OMGHTTPURLRQ DELETE:@"http://api.com":@{@"key": @"value"}];
+```
+
+You can then pass these to an `NSURLConnection` or `NSURLSession`.
+
+
+## `multipart/form-data`
+
+OMG! Constructing multipart/form-data for POST requests is complicated, let us do it for you:
+
+```objc
+
+OMGMultipartFormData *multipartFormData = [OMGMultipartFormData new];
+
+NSData *data1 = [NSData dataWithContentsOfFile:@"myimage1.png"];
+[multipartFormData addFile:data1 parameterName:@"file1" filename:@"myimage1.png" contentType:@"image/png"];
+
+// Ideally you would not want to re-encode the PNG, but often it is
+// tricky to avoid it.
+UIImage *image2 = [UIImage imageNamed:@"image2"];
+NSData *data2 = UIImagePNGRepresentation(image2);
+[multipartFormData addFile:data2 parameterName:@"file2" filename:@"myimage2.png" contentType:@"image/png"];
+
+// SUPER Ideally you would not want to re-encode the JPEG as the process
+// is lossy. If you image comes from the AssetLibrary you *CAN* get the
+// original `NSData`. See stackoverflow.com.
+UIImage *image3 = [UIImage imageNamed:@"image3"];
+NSData *data3 = UIImageJPEGRepresentation(image3);
+[multipartFormData addFile:data3 parameterName:@"file2" filename:@"myimage3.jpeg" contentType:@"image/jpeg"];
+
+NSMutableURLRequest *rq = [OMGHTTPURLRQ POST:url:multipartFormData];
+```
+
+Now feed `rq` to `[NSURLConnection sendSynchronousRequest:returningResponse:error:`.
+
+
+## Configuring an `NSURLSessionUploadTask`
+
+If you need to use `NSURLSession`’s `uploadTask:` but you have become frustrated  because your endpoint expects a multipart/form-data POST request and `NSURLSession` sends the data *raw*, use this:
+
+```objc
+id config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:someID];
+id session = [NSURLSession sessionWithConfiguration:config delegate:someObject delegateQueue:[NSOperationQueue new]];
+
+OMGMultipartFormData *multipartFormData = [OMGMultipartFormData new];
+[multipartFormDatabuilder addFile:data parameterName:@"file" filename:nil contentType:nil];
+
+NSURLRequest *rq = [OMGHTTPURLRQ POST:urlString:multipartFormData];
+
+id path = [[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject] stringByAppendingPathComponent:@"upload.NSData"];
+[rq.HTTPBody writeToFile:path atomically:YES];
+
+[[session uploadTaskWithRequest:rq fromFile:[NSURL fileURLWithPath:path]] resume];
+```
+
+
+## OMGUserAgent
+
+If you just need a sensible UserAgent string for your application you can `pod OMGHTTPURLRQ/UserAgent` and then:
+
+```objc
+#import <OMGHTTPURLRQ/OMGUserAgent.h>
+
+NSString *userAgent = OMGUserAgent();
+```
+
+OMGHTTPURLRQ adds this User-Agent to all requests it generates automatically.
+
+So for URLRequests generated **other** than by OMGHTTPURLRQ you would do:
+
+```objc
+[someURLRequest addValue:OMGUserAgent() forHTTPHeaderField:@"User-Agent"];
+```
+
+
+# Twitter Reverse Auth
+
+You need an OAuth library, here we use the [TDOAuth](https://github.com/tweetdeck/TDOAuth) pod. You also need
+your API keys that registering at https://dev.twitter.com will provide
+you.
+
+```objc
+NSMutableURLRequest *rq = [TDOAuth URLRequestForPath:@"/oauth/request_token" POSTParameters:@{@"x_auth_mode" : @"reverse_auth"} host:@"api.twitter.com"consumerKey:APIKey consumerSecret:APISecret accessToken:nil tokenSecret:nil];
+[rq addValue:OMGUserAgent() forHTTPHeaderField:@"User-Agent"];
+
+[NSURLConnection sendAsynchronousRequest:rq queue:nil completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
+    id oauth = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    SLRequest *reverseAuth = [SLRequest requestForServiceType:SLServiceTypeTwitter requestMethod:SLRequestMethodPOST URL:[NSURL URLWithString:@"https://api.twitter.com/oauth/access_token"] parameters:@{
+        @"x_reverse_auth_target": APIKey,
+        @"x_reverse_auth_parameters": oauth
+    }];
+    reverseAuth.account = account;
+    [reverseAuth performRequestWithHandler:^(NSData *data, NSHTTPURLResponse *urlResponse, NSError *error) {
+        id creds = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        id credsDict = [NSMutableDictionary new];
+        for (__strong id pair in [creds componentsSeparatedByString:@"&"]) {
+            pair = [pair componentsSeparatedByString:@"="];
+            credsDict[pair[0]] = pair[1];
+        }
+        NSLog(@"%@", credsDict);
+    }];
+}];
+```
+
+
+# License
+
+```
+Copyright 2014 Max Howell <mxcl@me.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```

--- a/TDOAuthTest/TDOAuthTest/TDOAuthTest-Info.plist
+++ b/TDOAuthTest/TDOAuthTest/TDOAuthTest-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.tweetdeck.tdoauth.tests</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/TDOAuthTest/TDOAuthTest/TDOAuthTest-Prefix.pch
+++ b/TDOAuthTest/TDOAuthTest/TDOAuthTest-Prefix.pch
@@ -1,0 +1,9 @@
+//
+//  Prefix header
+//
+//  The contents of this file are implicitly included at the beginning of every source file.
+//
+
+#ifdef __OBJC__
+    #import <Cocoa/Cocoa.h>
+#endif

--- a/TDOAuthTest/TDOAuthTest/TDOAuthTest.h
+++ b/TDOAuthTest/TDOAuthTest/TDOAuthTest.h
@@ -1,0 +1,18 @@
+//
+//  TDOAuthTest.h
+//  TDOAuthTest
+//
+//  Created by Bob Fitterman on 3/22/15.
+//
+//
+
+#import <XCTest/XCTest.h>
+#import "TDOAuth.h"
+
+@interface TDOAuthTest : XCTestCase {
+@private
+    NSURLRequest        *getRequest;
+    NSURLRequest        *postRequest;
+}
+
+@end

--- a/TDOAuthTest/TDOAuthTest/TDOAuthTest.h
+++ b/TDOAuthTest/TDOAuthTest/TDOAuthTest.h
@@ -10,7 +10,7 @@
 #import "TDOAuth.h"
 
 @interface TDOAuthTest : XCTestCase {
-@private
+@public
     NSURLRequest        *getRequest;
     NSURLRequest        *postRequest;
 }

--- a/TDOAuthTest/TDOAuthTest/TDOAuthTest.h
+++ b/TDOAuthTest/TDOAuthTest/TDOAuthTest.h
@@ -9,10 +9,5 @@
 #import <XCTest/XCTest.h>
 #import "TDOAuth.h"
 
-@interface TDOAuthTest : XCTestCase {
-@public
-    NSURLRequest        *getRequest;
-    NSURLRequest        *postRequest;
-}
-
+@interface TDOAuthTest : XCTestCase
 @end

--- a/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
+++ b/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
@@ -122,6 +122,10 @@
     XCTAssert([contentLength isEqualToString:@"7"],
               @"Content-Length is not expected value)");
 
+    NSString *acceptValue = [postRequest valueForHTTPHeaderField: @"Accept"];
+    XCTAssertNil(acceptValue,
+                 @"Accept is not expected value)");
+
 }
 - (void)testPostHeaderAuthField
 {
@@ -232,7 +236,7 @@
                                                   tokenSecret:@"mnop"
                                                        scheme:@"ftp" // Not really valid, but it lets us test
                                                        method:@"BEG"
-                                                 headerValues:nil
+                                                 headerValues:@{@"Accept": @"application/json"}
                                               signatureMethod:nil];
     NSString *url = [[genericRequest URL] absoluteString];
     XCTAssert([url isEqualToString:@"ftp://api.example.com/service"],
@@ -246,6 +250,9 @@
     XCTAssert([contentLength isEqualToString:@"16"],
               @"Content-Length is not expected value)");
 
+    NSString *acceptValue = [genericRequest valueForHTTPHeaderField: @"Accept"];
+    XCTAssert([acceptValue isEqualToString:@"application/json"],
+              @"Accept is not expected value)");
 }
 - (void)testGenericHeaderAuthField
 {

--- a/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
+++ b/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
@@ -1,0 +1,133 @@
+//
+//  TDOAuthTest.m
+//  TDOAuthTest
+//
+//  Created by Bob Fitterman on 3/22/15.
+//
+//
+
+#import <XCTest/XCTest.h>
+#import "TDOAuthTest.h"
+
+@implementation TDOAuthTest
+
+- (void)setUp
+{
+    [super setUp];
+    getRequest = [TDOAuth URLRequestForPath:@"/service"
+                              GETParameters:@{@"foo": @"bar"}
+                                       host:@"api.example.com"
+                                consumerKey:@"abcd"
+                             consumerSecret:@"efgh"
+                                accessToken:@"ijkl"
+                                tokenSecret:@"mnop"];
+    postRequest = [TDOAuth URLRequestForPath:@"/service"
+                              POSTParameters:@{@"foo": @"bar"}
+                                        host:@"api.example.com"
+                                 consumerKey:@"abcd"
+                              consumerSecret:@"efgh"
+                                 accessToken:@"ijkl"
+                                 tokenSecret:@"mnop"];
+
+}
+
+- (void)tearDown
+{
+    getRequest = nil;
+    [super tearDown];
+}
+
+- (void)testGetMethod
+{
+    
+    XCTAssert([[getRequest HTTPMethod] isEqualToString:@"GET"],
+              "method (verb) expected to be GET");
+}
+
+- (void)testGetBody
+{
+    NSData *body = [getRequest HTTPBody];
+    //NSString *bodyString = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
+    XCTAssertNil(body,
+                 "body expected to be nil");
+}
+
+- (void)testGetUrl
+{
+    NSString *url = [[getRequest URL] absoluteString];
+    XCTAssert([url isEqualToString:@"http://api.example.com/service?foo=bar"],
+              "url does not match expected value");
+
+    NSString *contentType = [getRequest valueForHTTPHeaderField: @"Content-Type"];
+    XCTAssertNil(contentType,
+              @"Content-Type was present when not expected)");
+    
+    NSString *contentLength = [getRequest valueForHTTPHeaderField: @"Content-Length"];
+    XCTAssertNil(contentLength,
+              @"Content-Length was set when not expected)");
+    
+}
+
+- (void)testGetUrlWithHttps
+{
+    
+    NSURLRequest *httpsRequest = [TDOAuth URLRequestForPath: @"/service"
+                                              GETParameters:@{@"foo": @"bar"}
+                                                     scheme:@"https"
+                                                       host:@"api.example.com"
+                                                consumerKey:@"abcd"
+                                             consumerSecret:@"efgh"
+                                                accessToken:@"ijkl"
+                                                tokenSecret:@"mnop"];
+    NSString *url = [[httpsRequest URL] absoluteString];
+    XCTAssert([url isEqualToString:@"https://api.example.com/service?foo=bar"],
+              @"url does not match expected value");
+
+
+}
+- (void)testGetHeaderAuthField
+{
+    // Not a very complete test. It needs to parse the whole thing and force the time to a set value.
+    NSString *authHeader = [getRequest valueForHTTPHeaderField:@"Authorization"];
+    //OAuth oauth_token="ijkl", oauth_nonce="DCD69F8B-654C-4316-ACC3-891F4FE561D4", oauth_signature_method="HMAC-SHA1", oauth_consumer_key="abcd", oauth_timestamp="1427068142", oauth_version="1.0", oauth_signature="9NQezmVaPBLhnvpRQ6LPawoiBDw%3D"
+    XCTAssert([authHeader hasPrefix:@"OAuth oauth_token=\"ijkl\", oauth_nonce=\""],
+              @"Expected beginning of header to be canned value");
+}
+
+- (void)testPostMethod
+{
+    XCTAssert([[postRequest HTTPMethod] isEqualToString:@"POST"],
+              "method (verb) expected to be POST");
+}
+- (void)testPostBody
+{
+    NSData *body = [postRequest HTTPBody];
+    NSString *bodyString = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
+    XCTAssert([bodyString isEqualToString:@"foo=bar"],
+              "body expected to be structured");
+}
+
+- (void)testPostUrl
+{
+    NSString *url = [[postRequest URL] absoluteString];
+    XCTAssert([url isEqualToString:@"https://api.example.com/service"],
+              "url does not match expected value");
+    
+    NSString *contentType = [postRequest valueForHTTPHeaderField: @"Content-Type"];
+    XCTAssert([contentType isEqualToString:@"application/x-www-form-urlencoded"],
+              @"Content-Type is not expected value)");
+
+    NSString *contentLength = [postRequest valueForHTTPHeaderField: @"Content-Length"];
+    XCTAssert([contentLength isEqualToString:@"7"],
+              @"Content-Length is not expected value)");
+
+}
+- (void)testPostHeaderAuthField
+{
+    // Not a very complete test. It needs to parse the whole thing and force the time to a set value.
+    NSString *authHeader = [getRequest valueForHTTPHeaderField:@"Authorization"];
+    //OAuth oauth_token="ijkl", oauth_nonce="DCD69F8B-654C-4316-ACC3-891F4FE561D4", oauth_signature_method="HMAC-SHA1", oauth_consumer_key="abcd", oauth_timestamp="1427068142", oauth_version="1.0", oauth_signature="9NQezmVaPBLhnvpRQ6LPawoiBDw%3D"
+    XCTAssert([authHeader hasPrefix:@"OAuth oauth_token=\"ijkl\", oauth_nonce=\""],
+              @"Expected beginning of header to be canned value");
+}
+@end

--- a/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
+++ b/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
@@ -51,7 +51,7 @@
                           accessToken:@"ijkl"
                           tokenSecret:@"mnop"
                                scheme:@"http"
-                               method:@"BEG"
+                        requestMethod:@"BEG"
                          headerValues:nil
                       signatureMethod:TDOAuthSignatureMethodHmacSha1];
 }
@@ -183,7 +183,7 @@
                                                   accessToken:@"ijkl"
                                                   tokenSecret:@"mnop"
                                                        scheme:@"http"
-                                                       method:@"BEG"
+                                                requestMethod:@"BEG"
                                                  headerValues:nil
                                               signatureMethod:TDOAuthSignatureMethodHmacSha1];
     XCTAssertNil(genericRequest,
@@ -200,7 +200,7 @@
                                                   accessToken:@"ijkl"
                                                   tokenSecret:@"mnop"
                                                        scheme:@"http"
-                                                       method:@"BEG"
+                                                requestMethod:@"BEG"
                                                  headerValues:nil
                                               signatureMethod:TDOAuthSignatureMethodHmacSha1];
     XCTAssertNil(genericRequest,
@@ -218,7 +218,7 @@
                                                   accessToken:@"ijkl"
                                                   tokenSecret:@"mnop"
                                                        scheme:nil
-                                                       method:@"BEG"
+                                                requestMethod:@"BEG"
                                                  headerValues:nil
                                               signatureMethod:TDOAuthSignatureMethodHmacSha1];
     XCTAssertNil(genericRequest,
@@ -235,7 +235,7 @@
                                                   accessToken:@"ijkl"
                                                   tokenSecret:@"mnop"
                                                        scheme:@"http"
-                                                       method:nil
+                                                requestMethod:nil
                                                  headerValues:nil
                                               signatureMethod:TDOAuthSignatureMethodHmacSha1];
     XCTAssertNil(genericRequest,
@@ -252,7 +252,7 @@
                                                   accessToken:@"ijkl"
                                                   tokenSecret:@"mnop"
                                                        scheme:@"ftp" // Not really valid, but it lets us test
-                                                       method:@"BEG"
+                                                requestMethod:@"BEG"
                                                  headerValues:@{@"Accept": @"application/json"}
                                               signatureMethod:TDOAuthSignatureMethodHmacSha1];
     NSString *url = [[genericRequest URL] absoluteString];
@@ -293,7 +293,7 @@
                                                   accessToken:@"ijkl"
                                                   tokenSecret:@"mnop"
                                                        scheme:@"ftp" // Not really valid, but it lets us test
-                                                       method:@"BEG"
+                                                requestMethod:@"BEG"
                                                  headerValues:nil
                                               signatureMethod:TDOAuthSignatureMethodHmacSha256];
     NSString *authHeader = [genericRequest valueForHTTPHeaderField:@"Authorization"];
@@ -315,7 +315,7 @@
                                                   accessToken:@"ijkl"
                                                   tokenSecret:@"mnop"
                                                        scheme:@"ftp" // Not really valid, but it lets us test
-                                                       method:@"BEG"
+                                                requestMethod:@"BEG"
                                                  headerValues:nil
                                               signatureMethod:(TDOAuthSignatureMethod)1234];
     XCTAssertNil(genericRequest,

--- a/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
+++ b/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
@@ -87,7 +87,7 @@
     NSString *contentLength = [getRequest valueForHTTPHeaderField: @"Content-Length"];
     XCTAssertNil(contentLength,
               @"Content-Length was set when not expected)");
-    
+
 }
 
 - (void)testGetUrlWithHttps

--- a/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
+++ b/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
@@ -15,35 +15,57 @@
 {
     [super setUp];
     [TDOAuth enableStaticValuesForAutomatedTests];
-    getRequest = [TDOAuth URLRequestForPath:@"/service"
-                              GETParameters:@{@"foo": @"bar"}
-                                       host:@"api.example.com"
-                                consumerKey:@"abcd"
-                             consumerSecret:@"efgh"
-                                accessToken:@"ijkl"
-                                tokenSecret:@"mnop"];
-    postRequest = [TDOAuth URLRequestForPath:@"/service"
-                              POSTParameters:@{@"foo": @"bar"}
-                                        host:@"api.example.com"
-                                 consumerKey:@"abcd"
-                              consumerSecret:@"efgh"
-                                 accessToken:@"ijkl"
-                                 tokenSecret:@"mnop"];}
-
+}
 - (void)tearDown
 {
-    getRequest = nil;
     [super tearDown];
+}
+
++ (NSURLRequest *)makeGetRequest
+{
+    return [TDOAuth URLRequestForPath:@"/service"
+                        GETParameters:@{@"foo": @"bar"}
+                                 host:@"api.example.com"
+                          consumerKey:@"abcd"
+                       consumerSecret:@"efgh"
+                          accessToken:@"ijkl"
+                          tokenSecret:@"mnop"];
+}
++ (NSURLRequest *)makePostRequest
+{
+    return [TDOAuth URLRequestForPath:@"/service"
+                       POSTParameters:@{@"foo": @"bar"}
+                                 host:@"api.example.com"
+                          consumerKey:@"abcd"
+                       consumerSecret:@"efgh"
+                          accessToken:@"ijkl"
+                          tokenSecret:@"mnop"];
+}
++ (NSURLRequest *)makeGenericRequest
+{
+    return [TDOAuth URLRequestForPath:@"/service"
+                           parameters:@{@"foo": @"bar", @"baz": @"bonk"}
+                                 host:@"api.example.com"
+                          consumerKey:@"abcd"
+                       consumerSecret:@"efgh"
+                          accessToken:@"ijkl"
+                          tokenSecret:@"mnop"
+                               scheme:@"http"
+                               method:@"BEG"
+                         headerValues:nil
+                      signatureMethod:TDOAuthSignatureMethodHmacSha1];
 }
 
 - (void)testGetMethod
 {
+    NSURLRequest *getRequest = [TDOAuthTest makeGetRequest];
     XCTAssert([[getRequest HTTPMethod] isEqualToString:@"GET"],
               "method (verb) expected to be GET");
 }
 
 - (void)testGetBody
 {
+    NSURLRequest *getRequest = [TDOAuthTest makeGetRequest];
     NSData *body = [getRequest HTTPBody];
     //NSString *bodyString = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
     XCTAssertNil(body,
@@ -52,6 +74,7 @@
 
 - (void)testGetUrl
 {
+    NSURLRequest *getRequest = [TDOAuthTest makeGetRequest];
     NSString *url = [[getRequest URL] absoluteString];
     XCTAssert([url isEqualToString:@"http://api.example.com/service?foo=bar"],
               "url does not match expected value");
@@ -68,7 +91,6 @@
 
 - (void)testGetUrlWithHttps
 {
-    
     NSURLRequest *httpsRequest = [TDOAuth URLRequestForPath: @"/service"
                                               GETParameters:@{@"foo": @"bar"}
                                                      scheme:@"https"
@@ -85,6 +107,7 @@
 }
 - (void)testGetHeaderAuthField
 {
+    NSURLRequest *getRequest = [TDOAuthTest makeGetRequest];
     NSString *authHeader = [getRequest valueForHTTPHeaderField:@"Authorization"];
     NSString *expectedHeader = @"OAuth oauth_token=\"ijkl\", "\
                                 "oauth_nonce=\"static-nonce-for-testing\", "\
@@ -97,11 +120,13 @@
 
 - (void)testPostMethod
 {
+    NSURLRequest *postRequest = [TDOAuthTest makePostRequest];
     XCTAssert([[postRequest HTTPMethod] isEqualToString:@"POST"],
               "method (verb) expected to be POST");
 }
 - (void)testPostBody
 {
+    NSURLRequest *postRequest = [TDOAuthTest makePostRequest];
     NSData *body = [postRequest HTTPBody];
     NSString *bodyString = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
     XCTAssert([bodyString isEqualToString:@"foo=bar"],
@@ -110,6 +135,7 @@
 
 - (void)testPostUrl
 {
+    NSURLRequest *postRequest = [TDOAuthTest makePostRequest];
     NSString *url = [[postRequest URL] absoluteString];
     XCTAssert([url isEqualToString:@"https://api.example.com/service"],
               "url does not match expected value");
@@ -129,6 +155,7 @@
 }
 - (void)testPostHeaderAuthField
 {
+    NSURLRequest *postRequest = [TDOAuthTest makePostRequest];
     NSString *authHeader = [postRequest valueForHTTPHeaderField:@"Authorization"];
     NSString *expectedHeader = @"OAuth oauth_token=\"ijkl\", "\
     "oauth_nonce=\"static-nonce-for-testing\", "\
@@ -141,17 +168,7 @@
 
 - (void)testGenericCallHasRightMethod
 {
-    NSURLRequest *genericRequest = [TDOAuth URLRequestForPath:@"/service"
-                                                   parameters:@{@"foo": @"bar"}
-                                                         host:@"api.example.com"
-                                                  consumerKey:@"abcd"
-                                               consumerSecret:@"efgh"
-                                                  accessToken:@"ijkl"
-                                                  tokenSecret:@"mnop"
-                                                       scheme:@"http"
-                                                       method:@"BEG"
-                                                 headerValues:nil
-                                              signatureMethod:nil];
+    NSURLRequest *genericRequest = [TDOAuthTest makeGenericRequest];
     XCTAssert([[genericRequest HTTPMethod] isEqualToString:@"BEG"],
               "method (verb) expected to be BEG");
 }
@@ -168,7 +185,7 @@
                                                        scheme:@"http"
                                                        method:@"BEG"
                                                  headerValues:nil
-                                              signatureMethod:nil];
+                                              signatureMethod:TDOAuthSignatureMethodHmacSha1];
     XCTAssertNil(genericRequest,
                  "should fail when path is missing");
 }
@@ -185,7 +202,7 @@
                                                        scheme:@"http"
                                                        method:@"BEG"
                                                  headerValues:nil
-                                              signatureMethod:nil];
+                                              signatureMethod:TDOAuthSignatureMethodHmacSha1];
     XCTAssertNil(genericRequest,
                  "should fail when host is missing");
 }
@@ -203,7 +220,7 @@
                                                        scheme:nil
                                                        method:@"BEG"
                                                  headerValues:nil
-                                              signatureMethod:nil];
+                                              signatureMethod:TDOAuthSignatureMethodHmacSha1];
     XCTAssertNil(genericRequest,
               "should fail when scheme is missing");
 }
@@ -220,7 +237,7 @@
                                                        scheme:@"http"
                                                        method:nil
                                                  headerValues:nil
-                                              signatureMethod:nil];
+                                              signatureMethod:TDOAuthSignatureMethodHmacSha1];
     XCTAssertNil(genericRequest,
                  "should fail when method is missing");
 }
@@ -237,7 +254,7 @@
                                                        scheme:@"ftp" // Not really valid, but it lets us test
                                                        method:@"BEG"
                                                  headerValues:@{@"Accept": @"application/json"}
-                                              signatureMethod:nil];
+                                              signatureMethod:TDOAuthSignatureMethodHmacSha1];
     NSString *url = [[genericRequest URL] absoluteString];
     XCTAssert([url isEqualToString:@"ftp://api.example.com/service"],
               "url does not match expected value");
@@ -256,23 +273,13 @@
 }
 - (void)testGenericHeaderAuthField
 {
-    NSURLRequest *genericRequest = [TDOAuth URLRequestForPath:@"/service"
-                                                   parameters:@{@"foo": @"bar", @"baz": @"bonk"}
-                                                         host:@"api.example.com"
-                                                  consumerKey:@"abcd"
-                                               consumerSecret:@"efgh"
-                                                  accessToken:@"ijkl"
-                                                  tokenSecret:@"mnop"
-                                                       scheme:@"ftp" // Not really valid, but it lets us test
-                                                       method:@"BEG"
-                                                 headerValues:nil
-                                              signatureMethod:nil];
+    NSURLRequest *genericRequest = [TDOAuthTest makeGenericRequest];
     NSString *authHeader = [genericRequest valueForHTTPHeaderField:@"Authorization"];
     NSString *expectedHeader = @"OAuth oauth_token=\"ijkl\", "\
     "oauth_nonce=\"static-nonce-for-testing\", "\
     "oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"abcd\", "\
     "oauth_timestamp=\"1456789012\", oauth_version=\"1.0\", "\
-    "oauth_signature=\"432kDrQVWpMi1PNf3OSbOe9gcw8%3D\"";
+    "oauth_signature=\"ycBj862NX5D9cCFrtWcBU2uzkdc%3D\"";
     XCTAssert([authHeader isEqualToString:expectedHeader],
               @"Expected header value does does not match");
 }
@@ -288,35 +295,13 @@
                                                        scheme:@"ftp" // Not really valid, but it lets us test
                                                        method:@"BEG"
                                                  headerValues:nil
-                                              signatureMethod:@"HMAC-SHA256"];
+                                              signatureMethod:TDOAuthSignatureMethodHmacSha256];
     NSString *authHeader = [genericRequest valueForHTTPHeaderField:@"Authorization"];
     NSString *expectedHeader = @"OAuth oauth_token=\"ijkl\", "\
     "oauth_nonce=\"static-nonce-for-testing\", "\
     "oauth_signature_method=\"HMAC-SHA256\", oauth_consumer_key=\"abcd\", "\
     "oauth_timestamp=\"1456789012\", oauth_version=\"1.0\", "\
     "oauth_signature=\"pRxssqcfFnrUqF7i2L5j%2BpCk57gu33m3c9az5kNGors%3D\"";
-    XCTAssert([authHeader isEqualToString:expectedHeader],
-              @"Expected header value does does not match");
-}
-- (void)testGenericHeaderRecognizesSHA1
-{
-    NSURLRequest *genericRequest = [TDOAuth URLRequestForPath:@"/service"
-                                                   parameters:@{@"foo": @"bar", @"baz": @"bonk"}
-                                                         host:@"api.example.com"
-                                                  consumerKey:@"abcd"
-                                               consumerSecret:@"efgh"
-                                                  accessToken:@"ijkl"
-                                                  tokenSecret:@"mnop"
-                                                       scheme:@"ftp" // Not really valid, but it lets us test
-                                                       method:@"BEG"
-                                                 headerValues:nil
-                                              signatureMethod:@"HMAC-SHA1"];
-    NSString *authHeader = [genericRequest valueForHTTPHeaderField:@"Authorization"];
-    NSString *expectedHeader = @"OAuth oauth_token=\"ijkl\", "\
-    "oauth_nonce=\"static-nonce-for-testing\", "\
-    "oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"abcd\", "\
-    "oauth_timestamp=\"1456789012\", oauth_version=\"1.0\", "\
-    "oauth_signature=\"432kDrQVWpMi1PNf3OSbOe9gcw8%3D\"";
     XCTAssert([authHeader isEqualToString:expectedHeader],
               @"Expected header value does does not match");
 }
@@ -332,7 +317,7 @@
                                                        scheme:@"ftp" // Not really valid, but it lets us test
                                                        method:@"BEG"
                                                  headerValues:nil
-                                              signatureMethod:@"HMAC-SHA333"];
+                                              signatureMethod:(TDOAuthSignatureMethod)1234];
     XCTAssertNil(genericRequest,
                  @"Expected request to fail with invalid hash function");
 }

--- a/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
+++ b/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
@@ -87,7 +87,6 @@
 }
 - (void)testGetHeaderAuthField
 {
-    // Not a very complete test. It needs to parse the whole thing and force the time to a set value.
     NSString *authHeader = [getRequest valueForHTTPHeaderField:@"Authorization"];
     NSString *expectedHeader = @"OAuth oauth_token=\"ijkl\", "\
                                 "oauth_nonce=\"static-nonce-for-testing\", "\
@@ -128,10 +127,13 @@
 }
 - (void)testPostHeaderAuthField
 {
-    // Not a very complete test. It needs to parse the whole thing and force the time to a set value.
-    NSString *authHeader = [getRequest valueForHTTPHeaderField:@"Authorization"];
-    //OAuth oauth_token="ijkl", oauth_nonce="DCD69F8B-654C-4316-ACC3-891F4FE561D4", oauth_signature_method="HMAC-SHA1", oauth_consumer_key="abcd", oauth_timestamp="1427068142", oauth_version="1.0", oauth_signature="9NQezmVaPBLhnvpRQ6LPawoiBDw%3D"
-    XCTAssert([authHeader hasPrefix:@"OAuth oauth_token=\"ijkl\", oauth_nonce=\""],
-              @"Expected beginning of header to be canned value");
+    NSString *authHeader = [postRequest valueForHTTPHeaderField:@"Authorization"];
+    NSString *expectedHeader = @"OAuth oauth_token=\"ijkl\", "\
+    "oauth_nonce=\"static-nonce-for-testing\", "\
+    "oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"abcd\", "\
+    "oauth_timestamp=\"1456789012\", oauth_version=\"1.0\", "\
+    "oauth_signature=\"pr%2ForWfyT9CsKTGW85AwjHmFjd8%3D\"";
+    XCTAssert([authHeader isEqualToString:expectedHeader],
+              @"Expected header value does does not match");
 }
 @end

--- a/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
+++ b/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
@@ -28,9 +28,7 @@
                                  consumerKey:@"abcd"
                               consumerSecret:@"efgh"
                                  accessToken:@"ijkl"
-                                 tokenSecret:@"mnop"];
-
-}
+                                 tokenSecret:@"mnop"];}
 
 - (void)tearDown
 {
@@ -136,4 +134,126 @@
     XCTAssert([authHeader isEqualToString:expectedHeader],
               @"Expected header value does does not match");
 }
+
+- (void)testGenericCallHasRightMethod
+{
+    NSURLRequest *genericRequest = [TDOAuth URLRequestForPath:@"/service"
+                                                   parameters:@{@"foo": @"bar"}
+                                                         host:@"api.example.com"
+                                                  consumerKey:@"abcd"
+                                               consumerSecret:@"efgh"
+                                                  accessToken:@"ijkl"
+                                                  tokenSecret:@"mnop"
+                                                       scheme:@"http"
+                                                       method:@"BEG"];
+    XCTAssert([[genericRequest HTTPMethod] isEqualToString:@"BEG"],
+              "method (verb) expected to be BEG");
+}
+
+- (void)testGenericRequiresPath
+{
+    NSURLRequest *genericRequest = [TDOAuth URLRequestForPath:nil
+                                                   parameters:@{@"foo": @"bar", @"baz": @"bonk"}
+                                                         host:@"api.example.com"
+                                                  consumerKey:@"abcd"
+                                               consumerSecret:@"efgh"
+                                                  accessToken:@"ijkl"
+                                                  tokenSecret:@"mnop"
+                                                       scheme:@"http"
+                                                       method:@"BEG"];
+    XCTAssertNil(genericRequest,
+                 "should fail when path is missing");
+}
+
+- (void)testGenericRequiresHost
+{
+    NSURLRequest *genericRequest = [TDOAuth URLRequestForPath:@"/service"
+                                                   parameters:@{@"foo": @"bar", @"baz": @"bonk"}
+                                                         host:nil
+                                                  consumerKey:@"abcd"
+                                               consumerSecret:@"efgh"
+                                                  accessToken:@"ijkl"
+                                                  tokenSecret:@"mnop"
+                                                       scheme:@"http"
+                                                       method:@"BEG"];
+    XCTAssertNil(genericRequest,
+                 "should fail when host is missing");
+}
+
+
+- (void)testGenericRequiresScheme
+{
+    NSURLRequest *genericRequest = [TDOAuth URLRequestForPath:@"/service"
+                                                   parameters:@{@"foo": @"bar", @"baz": @"bonk"}
+                                                         host:@"api.example.com"
+                                                  consumerKey:@"abcd"
+                                               consumerSecret:@"efgh"
+                                                  accessToken:@"ijkl"
+                                                  tokenSecret:@"mnop"
+                                                       scheme:nil
+                                                       method:@"BEG"];
+    XCTAssertNil(genericRequest,
+              "should fail when scheme is missing");
+}
+
+- (void)testGenericRequiresMethod
+{
+    NSURLRequest *genericRequest = [TDOAuth URLRequestForPath:@"/service"
+                                                   parameters:@{@"foo": @"bar", @"baz": @"bonk"}
+                                                         host:@"api.example.com"
+                                                  consumerKey:@"abcd"
+                                               consumerSecret:@"efgh"
+                                                  accessToken:@"ijkl"
+                                                  tokenSecret:@"mnop"
+                                                       scheme:@"http"
+                                                       method:nil];
+    XCTAssertNil(genericRequest,
+                 "should fail when method is missing");
+}
+
+- (void)testGenericUrl
+{
+    NSURLRequest *genericRequest = [TDOAuth URLRequestForPath:@"/service"
+                                                   parameters:@{@"foo": @"bar", @"baz": @"bonk"}
+                                                         host:@"api.example.com"
+                                                  consumerKey:@"abcd"
+                                               consumerSecret:@"efgh"
+                                                  accessToken:@"ijkl"
+                                                  tokenSecret:@"mnop"
+                                                       scheme:@"ftp" // Not really valid, but it lets us test
+                                                       method:@"BEG"];
+    NSString *url = [[genericRequest URL] absoluteString];
+    XCTAssert([url isEqualToString:@"ftp://api.example.com/service"],
+              "url does not match expected value");
+
+    NSString *contentType = [genericRequest valueForHTTPHeaderField: @"Content-Type"];
+    XCTAssert([contentType isEqualToString:@"application/x-www-form-urlencoded"],
+              @"Content-Type is not expected value)");
+
+    NSString *contentLength = [genericRequest valueForHTTPHeaderField: @"Content-Length"];
+    XCTAssert([contentLength isEqualToString:@"16"],
+              @"Content-Length is not expected value)");
+
+}
+- (void)testGenericHeaderAuthField
+{
+    NSURLRequest *genericRequest = [TDOAuth URLRequestForPath:@"/service"
+                                                   parameters:@{@"foo": @"bar", @"baz": @"bonk"}
+                                                         host:@"api.example.com"
+                                                  consumerKey:@"abcd"
+                                               consumerSecret:@"efgh"
+                                                  accessToken:@"ijkl"
+                                                  tokenSecret:@"mnop"
+                                                       scheme:@"ftp" // Not really valid, but it lets us test
+                                                       method:@"BEG"];
+    NSString *authHeader = [genericRequest valueForHTTPHeaderField:@"Authorization"];
+    NSString *expectedHeader = @"OAuth oauth_token=\"ijkl\", "\
+    "oauth_nonce=\"static-nonce-for-testing\", "\
+    "oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"abcd\", "\
+    "oauth_timestamp=\"1456789012\", oauth_version=\"1.0\", "\
+    "oauth_signature=\"432kDrQVWpMi1PNf3OSbOe9gcw8%3D\"";
+    XCTAssert([authHeader isEqualToString:expectedHeader],
+              @"Expected header value does does not match");
+}
+
 @end

--- a/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
+++ b/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
@@ -14,6 +14,7 @@
 - (void)setUp
 {
     [super setUp];
+    [TDOAuth enableStaticValuesForAutomatedTests];
     getRequest = [TDOAuth URLRequestForPath:@"/service"
                               GETParameters:@{@"foo": @"bar"}
                                        host:@"api.example.com"
@@ -39,7 +40,6 @@
 
 - (void)testGetMethod
 {
-    
     XCTAssert([[getRequest HTTPMethod] isEqualToString:@"GET"],
               "method (verb) expected to be GET");
 }
@@ -89,9 +89,13 @@
 {
     // Not a very complete test. It needs to parse the whole thing and force the time to a set value.
     NSString *authHeader = [getRequest valueForHTTPHeaderField:@"Authorization"];
-    //OAuth oauth_token="ijkl", oauth_nonce="DCD69F8B-654C-4316-ACC3-891F4FE561D4", oauth_signature_method="HMAC-SHA1", oauth_consumer_key="abcd", oauth_timestamp="1427068142", oauth_version="1.0", oauth_signature="9NQezmVaPBLhnvpRQ6LPawoiBDw%3D"
-    XCTAssert([authHeader hasPrefix:@"OAuth oauth_token=\"ijkl\", oauth_nonce=\""],
-              @"Expected beginning of header to be canned value");
+    NSString *expectedHeader = @"OAuth oauth_token=\"ijkl\", "\
+                                "oauth_nonce=\"static-nonce-for-testing\", "\
+                                "oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"abcd\", "\
+                                "oauth_timestamp=\"1456789012\", oauth_version=\"1.0\", "\
+                                "oauth_signature=\"O4hspbDTqHlLdqfXxR0jSly9bkU%3D\"";
+    XCTAssert([authHeader isEqualToString:expectedHeader],
+              @"Expected header value does does not match");
 }
 
 - (void)testPostMethod

--- a/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
+++ b/TDOAuthTest/TDOAuthTest/TDOAuthTest.m
@@ -14,7 +14,6 @@
 - (void)setUp
 {
     [super setUp];
-    [TDOAuth enableStaticValuesForAutomatedTests];
 }
 - (void)tearDown
 {

--- a/TDOAuthTest/TDOAuthTest/en.lproj/InfoPlist.strings
+++ b/TDOAuthTest/TDOAuthTest/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Localized versions of Info.plist keys */
+


### PR DESCRIPTION
This pull request includes many new capabilities. The basic approach was to consolidate the GET and POST methods into a single base method that exposes configuration options and to turn the current public methods into convenience methods that access the merged method.

New parameters allow control over the request method, signature method, HTTP headers and how the data is transmitted (form or JSON in the body). Automated tests were added as well.