### PR TITLE
URLEncode request path for all requests

### DIFF
--- a/Tests/MainTests.m
+++ b/Tests/MainTests.m
@@ -440,4 +440,51 @@
                  @"Expected request to fail with invalid hash function");
 }
 
+- (void)testGenericURLEncoding {
+    NSURLRequest *genericRequest = [TDOAuth URLRequestForPath:@"/service/\\subDirectoryWithBackslash"
+                                                   parameters:@{@"foo": @"bar", @"baz": @"bonk"}
+                                                         host:@"api.example.com"
+                                                  consumerKey:@"abcd"
+                                               consumerSecret:@"efgh"
+                                                  accessToken:@"ijkl"
+                                                  tokenSecret:@"mnop"
+                                                       scheme:@"ftp" // Not really valid, but it lets us test
+                                                requestMethod:@"BEG"
+                                                 dataEncoding:TDOAuthContentTypeUrlEncodedForm
+                                                 headerValues:nil
+                                              signatureMethod:TDOAuthSignatureMethodHmacSha1];
+    NSString *url = [[genericRequest URL] absoluteString];
+    XCTAssertEqualObjects(url, @"ftp://api.example.com/service/%5CsubDirectoryWithBackslash",
+                          "url does not match expected value");
+
+    NSString *authHeader = [genericRequest valueForHTTPHeaderField:@"Authorization"];
+    NSString *expectedHeader = @"OAuth oauth_token=\"ijkl\", "\
+    "oauth_nonce=\"static-nonce-for-testing\", "\
+    "oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"abcd\", "\
+    "oauth_timestamp=\"1456789012\", oauth_version=\"1.0\", "\
+    "oauth_signature=\"SVHQ336AsUnnwG48LIsyr%2FYDi6A%3D\"";
+    XCTAssertEqualObjects(authHeader, expectedHeader, @"Expected header value does does not match");
+}
+
+- (void)testGetURLEncoding {
+    NSURLRequest *getRequest = [TDOAuth URLRequestForPath:@"/service/\\subDirectoryWithBackslash"
+                                            GETParameters:@{@"foo": @"bar", @"baz": @"bonk"}
+                                                     host:@"api.example.com"
+                                              consumerKey:@"abcd"
+                                           consumerSecret:@"efgh"
+                                              accessToken:@"ijkl"
+                                              tokenSecret:@"mnop"];
+    NSString *url = [[getRequest URL] absoluteString];
+    XCTAssertEqualObjects(url, @"http://api.example.com/service/%5CsubDirectoryWithBackslash?foo=bar&baz=bonk",
+              "url does not match expected value");
+
+    NSString *authHeader = [getRequest valueForHTTPHeaderField:@"Authorization"];
+    NSString *expectedHeader = @"OAuth oauth_token=\"ijkl\", "\
+    "oauth_nonce=\"static-nonce-for-testing\", "\
+    "oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"abcd\", "\
+    "oauth_timestamp=\"1456789012\", oauth_version=\"1.0\", "\
+    "oauth_signature=\"am5ojjNME7KLGoPwpBBGnAJA3g4%3D\"";
+    XCTAssertEqualObjects(authHeader, expectedHeader, @"Expected header value does does not match");
+}
+
 @end


### PR DESCRIPTION
I ran into an issue using TDOAuth with request paths containing characters that require URL encoding, specifically a path with a backslash in it. This change consistently encodes the request path for `GET` and generic requests in what I hope is the least surprising way.

Previously, if I used an unencoded backslash (`[TDOAuth URLRequestForPath:@"/service/\\subDirectoryWithBackslash"`) in a `GET` request, the URL would be constructed correctly, but the signature base string would not encode the `%5C` entity correctly (the `%` needs to be double-encoded in the base string, as the actual URL contains the encoded entity). 

Using an unencoded backslash for a `POST` request resulted in an attempt to construct an invalid URL containing a raw `\` character and a botched signature with a nil scheme.

**However**  trying to pre-encode the character: `[TDOAuth URLRequestForPath:@"/service/%5CsubDirectoryWithBackslash"`, resulted in the character being double-encoded for a `GET`, but _worked correctly for non-GET_. This change will break any users that depended on passing encoded path components for non `GET` requests. This seemed the best decision, since the parameter is named `unencodedPathWithoutQuery`, and this way the encoding is consistent between request methods.