### PR TITLE
Use URL parameters for DELETE and HEAD, in addition to GET.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Cartfile.resolved
 /Carthage
+xcuserdata

--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -262,7 +262,7 @@ static NSString* timestamp() {
     oauth->unencodedHostAndPathWithoutQuery = [host.lowercaseString stringByAppendingString:unencodedPathWithoutQuery];
 
     NSMutableURLRequest *rq;
-    if ([method isEqualToString:@"GET"])
+    if ([method isEqualToString:@"GET"] || [method isEqualToString:@"DELETE"] || [method isEqualToString:@"HEAD"])
     {
         // We don't use pcen as we don't want to percent encode eg. /, this is perhaps
         // not the most all encompassing solution, but in practice it seems to work

--- a/Tests/MainTests.m
+++ b/Tests/MainTests.m
@@ -40,7 +40,7 @@
                           accessToken:@"ijkl"
                           tokenSecret:@"mnop"];
 }
-+ (NSURLRequest *)makeGenericRequest
++ (NSURLRequest *)makeGenericRequestWithHTTPMethod:(NSString *)method
 {
     return [TDOAuth URLRequestForPath:@"/service"
                            parameters:@{@"foo": @"bar", @"baz": @"bonk"}
@@ -50,7 +50,7 @@
                           accessToken:@"ijkl"
                           tokenSecret:@"mnop"
                                scheme:@"http"
-                        requestMethod:@"BEG"
+                        requestMethod:method
                          dataEncoding:TDOAuthContentTypeUrlEncodedForm
                          headerValues:nil
                       signatureMethod:TDOAuthSignatureMethodHmacSha1];
@@ -166,9 +166,45 @@
               @"Expected header value does does not match");
 }
 
+- (void)testHeadUrl
+{
+    NSURLRequest *headRequest = [TDOAuthTest makeGenericRequestWithHTTPMethod:@"HEAD"];
+
+    NSString *url = [[headRequest URL] absoluteString];
+    XCTAssert([url isEqualToString:@"http://api.example.com/service?foo=bar&baz=bonk"],
+              "url does not match expected value");
+    
+    NSString *contentType = [headRequest valueForHTTPHeaderField: @"Content-Type"];
+    XCTAssertNil(contentType,
+                 @"Content-Type was present when not expected)");
+    
+    NSString *contentLength = [headRequest valueForHTTPHeaderField: @"Content-Length"];
+    XCTAssertNil(contentLength,
+                 @"Content-Length was set when not expected)");
+    
+}
+
+- (void)testDeleteUrl
+{
+    NSURLRequest *deleteRequest = [TDOAuthTest makeGenericRequestWithHTTPMethod:@"DELETE"];
+    
+    NSString *url = [[deleteRequest URL] absoluteString];
+    XCTAssert([url isEqualToString:@"http://api.example.com/service?foo=bar&baz=bonk"],
+              "url does not match expected value");
+    
+    NSString *contentType = [deleteRequest valueForHTTPHeaderField: @"Content-Type"];
+    XCTAssertNil(contentType,
+                 @"Content-Type was present when not expected)");
+    
+    NSString *contentLength = [deleteRequest valueForHTTPHeaderField: @"Content-Length"];
+    XCTAssertNil(contentLength,
+                 @"Content-Length was set when not expected)");
+    
+}
+
 - (void)testGenericCallHasRightMethod
 {
-    NSURLRequest *genericRequest = [TDOAuthTest makeGenericRequest];
+    NSURLRequest *genericRequest = [TDOAuthTest makeGenericRequestWithHTTPMethod:@"BEG"];
     XCTAssert([[genericRequest HTTPMethod] isEqualToString:@"BEG"],
               "method (verb) expected to be BEG");
 }
@@ -349,7 +385,7 @@
 }
 - (void)testGenericHeaderAuthField
 {
-    NSURLRequest *genericRequest = [TDOAuthTest makeGenericRequest];
+    NSURLRequest *genericRequest = [TDOAuthTest makeGenericRequestWithHTTPMethod:@"BEG"];
     NSString *authHeader = [genericRequest valueForHTTPHeaderField:@"Authorization"];
     NSString *expectedHeader = @"OAuth oauth_token=\"ijkl\", "\
     "oauth_nonce=\"static-nonce-for-testing\", "\


### PR DESCRIPTION
Previous approach of using entity for HEAD violates HTTP specification.
Delete is more of a gray area, but where additional data is required, it
is expected to be a heavy payload. URL params are more in the spirit of
HTTP and work with all server frameworks (unlike DELETE with entity)

Issue #17 